### PR TITLE
Consider removing ukkonen since it is an optional dependency?

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - pip
     - setuptools
   run:
-    - ukkonen
     - python >={{ python_min }}
 
 test:
@@ -38,7 +37,8 @@ test:
     - setup.py
   commands:
     - identify-cli --help
-    - pytest tests
+    # test_license_* tests needs ukonnen which is an optional dependency
+    - pytest tests -k 'not test_license'
 
 about:
   home: https://github.com/pre-commit/identify

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: a22c206a996684b2a29870aa4fd829b08ba1a61f3a2b68e1a3861b558a7f0517
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install . --no-deps --ignore-installed
   noarch: python
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - setup.py
   commands:
     - identify-cli --help
-    # test_license_* tests needs ukonnen which is an optional dependency
+    # test_license* tests needs ukonnen which is an optional dependency
     - pytest tests -k 'not test_license'
 
 about:


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

I was wondering if you would consider removing `ukonnen` since it is an optional dependency of `identify`, it is in `extra_requires` in `setup.cfg` see https://github.com/pre-commit/identify/blob/e31a62bc9f952165a259f30abcf13593fff3d128/setup.cfg#L31-L33.

That means that `pip install identify` does not install `ukkonen` but `conda install -c conda-forge identify` does install `ukkonen`.

It seems like `ukkonen` is used to [compare licenses](https://github.com/pre-commit/identify#identifying-license-files), I don't have a good feeling how much `conda` users who install `identify` are using this functionality and thus relying on `ukkonen` to be installed together with `identify`.

I would completely understand if maintainers prefer to keep it as it is and not remove the `ukkonen` dependency.

It looks like there was at least one attempt to remove the `ukkonen` optional dependency from this feedstock, but it was added back since the tests needed it, see https://github.com/conda-forge/identify-feedstock/pull/44/commits

### Why do I care (at least a little bit)?

If you install `pre-commit` with free-threaded Python 3.14, you get a broken pre-commit setup because it installs identify 1.2.2. The reason it does that is because `identify>=2` depends on `ukkonen` which doesn't have right now a Python 3.14 free-threaded conda-forge package.

If this PR was accepted (I completely understand if not), this would make everything work fine.

The alternative would be to have `conda-forge/ukonnen-feedstock` upload a package for free-threaded Python 3.14. I have a PoC with a `ukkonen` patch in https://github.com/conda-forge/ukkonen-feedstock/pull/12, but this seems like a more complicated approach with a lower success rate. In particular the patch would in principle be needed to be proposed to `ukkonen` so that it can build with free-threaded Python.

### How is it currently broken?

Here is the command to install the environment with pre-commit and free-threaded Python 3.14:
```
conda create -n test python=3.14 python-freethreading pre-commit
conda activate test
conda list | grep identify
```
Output:
```
identify                   1.2.2            py_0                  conda-forge
```

And with this `.pre-commit-config.yaml`:
```yaml
repos:
-   repo: https://github.com/astral-sh/ruff-pre-commit
    rev: v0.12.2
    hooks:
    -   id: ruff-check
        args: ["--fix", "--output-format=full"]
    -   id: ruff-format
```

running `pre-commit` yields the following error:
```
❯ pre-commit run ruff-check
An error has occurred: InvalidManifestError: 
==> File /home/lesteve/.cache/pre-commit/repoloe6fwq7/.pre-commit-hooks.yaml
==> At Hook(id='ruff-check')
==> At key: types_or
==> At index 2
=====> Type tag 'jupyter' is not recognized.  Try upgrading identify and pre-commit?
Check the log at /home/lesteve/.cache/pre-commit/pre-commit.log
```
